### PR TITLE
fix: allow interacting with embedded youtube player & enable keyboard shortcuts (backspace and 'k' to play/pause)

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -21,6 +21,11 @@ window.addEventListener('load', function() {
   player.once('play', function() {
     var videoWrapper = document.querySelector('.plyr__video-wrapper');
     videoWrapper.classList.add('hidden-poster');
+
+    const poster = videoWrapper.querySelector('.plyr__poster');
+    if (poster) {
+      poster.remove();
+    }
   });
 
   registerNavigation();

--- a/scripts.js
+++ b/scripts.js
@@ -17,7 +17,11 @@ window.addEventListener('load', function() {
     }
     stickyNavbarElement.classList.remove('visible');
   }
-  var player = new Plyr('#player');
+  var player = new Plyr('#player', {
+    keyboard: {
+      global: true,
+    },
+  });
   player.once('play', function() {
     var videoWrapper = document.querySelector('.plyr__video-wrapper');
     videoWrapper.classList.add('hidden-poster');


### PR DESCRIPTION
not sure if this is intentional but the current behavior doesn't allow us (at least on Firefox) to share the video or even open it on youtube, see:
 
[before.webm](https://github.com/nestjs/nestjs.com/assets/13461315/5b63701d-1feb-4847-b9d1-1201c63c50a7)

### now we can:

[now.webm](https://github.com/nestjs/nestjs.com/assets/13461315/c53d325a-45d9-4226-bbd0-f5643fa7cebe)

that's the same behavior as in https://plyr.io/#youtube but I don't know how they did in there