### PR TITLE
chore(assets): copy images in subfolders for build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "NestJS - official website",
   "scripts": {
     "build": "rm -rf dist && parcel build index.html --public-url ./ && npm run copy-assets",
-    "copy-assets": "copyfiles img/* dist",
+    "copy-assets": "copyfiles img/* img/**/* dist",
     "start": "parcel index.html",
     "start:watch": "parcel watch index.html"
   },


### PR DESCRIPTION
Assets moved in `icons` and `logos` subfolders of `img` were not copied in `dist` folder at build time.