### PR TITLE
add: show github stars

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,6 +75,7 @@
       src="https://use.fontawesome.com/releases/v6.4.2/js/all.js"
     ></script>
     <script type="module" src="scripts.js"></script>
+    <script type="module" src="./lib/fetchStars.js"></script>
     <!-- <link rel="stylesheet" href="lib/plyr.css" /> -->
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script
@@ -187,6 +188,7 @@
               class="icon m-l-30"
             >
               <i class="fa-brands fa-github"></i>
+              <span class="github-stars"></span>
             </a>
           </li>
           <li class="social-icon">
@@ -280,8 +282,8 @@
                   href="https://github.com/nestjs/nest"
                   target="_blank"
                   title="GitHub | NestJS - A progressive Node.js framework"
-                  ><span>GITHUB</span></a
-                >
+                  ><span>GITHUB</span> <span class="github-stars"></span
+                ></a>
               </li>
             </ul>
             <div class="mobile-nav-footer">
@@ -364,6 +366,7 @@
                   class="icon"
                 >
                   <i class="fa-brands fa-github"></i>
+                  <span class="github-stars"></span>
                 </a>
               </li>
               <li class="social-icon">
@@ -402,7 +405,9 @@
                 href="https://github.com/nestjs/nest"
                 class="btn btn-secondary d-inline-block"
               >
-                <i class="fa-brands fa-github"></i> <span>Source code</span>
+                <i class="fa-brands fa-github"></i>
+                <span class="github-stars"></span>
+                <span>Source code</span>
               </a>
             </div>
           </div>
@@ -1026,6 +1031,7 @@
         <div class="social-wrapper">
           <a href="https://github.com/nestjs/nest" target="_blank" class="icon">
             <i class="fab fa-github"></i>
+            <span class="github-stars"></span>
           </a>
           <a
             href="https://twitter.com/nestframework"
@@ -1078,4 +1084,5 @@
       </div>
     </footer>
   </body>
+  <script src="lib/fetchStars.js"></script>
 </html>

--- a/lib/fetchStars.js
+++ b/lib/fetchStars.js
@@ -1,0 +1,35 @@
+window.addEventListener("load", function () {
+  const owner = "nestjs";
+  const repo = "nest";
+  const apiUrl = `https://api.github.com/repos/${owner}/${repo}`;
+
+  fetch(apiUrl)
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error(`GitHub API error: ${response.status}`);
+      }
+      return response.json();
+    })
+    .then((data) => {
+      const stars = data.stargazers_count;
+      const formattedStars = formatStars(stars);
+      const elements = document.querySelectorAll(".github-stars");
+      //  looop in all the github icons
+      elements.forEach((el) => {
+        el.textContent = formattedStars;
+      });
+    })
+    .catch((error) => {
+      console.error("Failed to fetch stars:", error);
+    });
+
+  function formatStars(count) {
+    if (count >= 1_000_000) {
+      return (count / 1_000_000).toFixed(1).replace(/\.0$/, "") + "M";
+    } else if (count >= 1_000) {
+      return (count / 1_000).toFixed(1).replace(/\.0$/, "") + "k";
+    } else {
+      return count.toString();
+    }
+  }
+});

--- a/lib/fetchStars.js
+++ b/lib/fetchStars.js
@@ -12,7 +12,7 @@ window.addEventListener("load", function () {
     })
     .then((data) => {
       const stars = data.stargazers_count;
-      const formattedStars = formatStars(stars);
+      const formattedStars = formatDigit(stars);
       const elements = document.querySelectorAll(".github-stars");
       //  looop in all the github icons
       elements.forEach((el) => {
@@ -23,7 +23,7 @@ window.addEventListener("load", function () {
       console.error("Failed to fetch stars:", error);
     });
 
-  function formatStars(count) {
+  function formatDigit(count) {
     if (count >= 1_000_000) {
       return (count / 1_000_000).toFixed(1).replace(/\.0$/, "") + "M";
     } else if (count >= 1_000) {

--- a/main.css
+++ b/main.css
@@ -1591,6 +1591,6 @@ body.mobile-nav-open {
 
 .github-stars {
   font-size: 20px;
-  font-family: math;
+  font-family: "Gill Sans", "Gill Sans MT", Calibri, "Trebuchet MS", sans-serif;
   font-weight: 500;
 }

--- a/main.css
+++ b/main.css
@@ -1,7 +1,11 @@
 :root {
   --primary-color: #ea2845;
   --primary-accent-color: #ea2868;
-  --primary-gradient: linear-gradient(90deg, var(--primary-color) 0%, var(--primary-accent-color) 100%);
+  --primary-gradient: linear-gradient(
+    90deg,
+    var(--primary-color) 0%,
+    var(--primary-accent-color) 100%
+  );
 }
 
 html {
@@ -60,12 +64,12 @@ a:active {
   margin-left: 4px;
 }
 
-.nav-wrapper >li > span:hover > .arrow {
+.nav-wrapper > li > span:hover > .arrow {
   color: #ea2845;
   cursor: pointer;
 }
 
-.nav-wrapper  > li > a:hover,
+.nav-wrapper > li > a:hover,
 .nav-wrapper > li > span:hover,
 .sub-nav-wrapper li a:hover {
   background: var(--primary-gradient);
@@ -115,7 +119,7 @@ a:active {
   visibility: visible;
   opacity: 1;
   transform: translateY(0);
-} 
+}
 
 .sub-nav-outlet {
   visibility: hidden;
@@ -449,11 +453,9 @@ body.mobile-nav-open {
   border-radius: 30px;
   padding: 2px;
   background: var(--primary-gradient);
-  -webkit-mask: 
-    linear-gradient(#fff 0 0) content-box, 
-    linear-gradient(#fff 0 0);
+  -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
   -webkit-mask-composite: xor;
-          mask-composite: exclude;
+  mask-composite: exclude;
   pointer-events: none;
   z-index: 2;
 }
@@ -467,7 +469,9 @@ body.mobile-nav-open {
   background: transparent;
 }
 
-.btn-primary:hover span, .btn-primary:active span, .btn-primary:focus span {
+.btn-primary:hover span,
+.btn-primary:active span,
+.btn-primary:focus span {
   color: var(--primary-color);
   background: var(--primary-gradient);
   -webkit-background-clip: text;
@@ -486,11 +490,9 @@ body.mobile-nav-open {
   border-radius: 30px;
   padding: 2px;
   background: #fff;
-  -webkit-mask: 
-    linear-gradient(#fff 0 0) content-box, 
-    linear-gradient(#fff 0 0);
+  -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
   -webkit-mask-composite: xor;
-          mask-composite: exclude;
+  mask-composite: exclude;
   pointer-events: none;
   z-index: 2;
 }
@@ -755,7 +757,6 @@ body.mobile-nav-open {
 .support-section a:nth-child(2n) {
   background-color: transparent;
 }
-
 
 .support-section a img {
   max-width: 100%;
@@ -1094,11 +1095,11 @@ body.mobile-nav-open {
 }
 
 .card--dark {
-  background: #0E0E10;
+  background: #0e0e10;
 }
 
 .card--primary {
-  background: #EE1744;
+  background: #ee1744;
 }
 
 .card--dark,
@@ -1108,7 +1109,7 @@ body.mobile-nav-open {
 }
 
 .card--light {
-  background: #E7E7E7;
+  background: #e7e7e7;
   margin-top: 30px;
   min-height: 520px;
 }
@@ -1185,7 +1186,7 @@ body.mobile-nav-open {
 }
 
 .card--dark .btn-secondary:hover,
-.card--primary .btn-secondary:hover  {
+.card--primary .btn-secondary:hover {
   background: transparent;
 }
 
@@ -1246,12 +1247,12 @@ body.mobile-nav-open {
   box-shadow: -20px -20px 60px 15px hsl(0deg 0% 0% / 15%);
 }
 
-.card--dark .card-image > img  {
-  border: 12px solid #1C1C1E;
+.card--dark .card-image > img {
+  border: 12px solid #1c1c1e;
 }
 
 .card--primary .card-image > img {
-  border: 12px solid #EF254F;
+  border: 12px solid #ef254f;
 }
 
 .card--light .image-wrapper > img {
@@ -1304,7 +1305,8 @@ body.mobile-nav-open {
 }
 
 @media (max-width: 1199px) and (min-width: 992px) {
-  .card--dark, .card--primary {
+  .card--dark,
+  .card--primary {
     min-height: 640px;
   }
 
@@ -1351,14 +1353,15 @@ body.mobile-nav-open {
     font-size: 28px;
   }
 
-  .card--dark, .card--primary {
+  .card--dark,
+  .card--primary {
     min-height: 640px;
   }
 
   .card--light {
     min-height: 580px;
   }
-  
+
   .card--light .card-image {
     bottom: -120px;
     width: 700px;
@@ -1366,7 +1369,8 @@ body.mobile-nav-open {
 }
 
 @media (max-width: 480px) {
-  .card--dark, .card--primary {
+  .card--dark,
+  .card--primary {
     min-height: 580px;
   }
 
@@ -1376,7 +1380,8 @@ body.mobile-nav-open {
 }
 
 @media (max-width: 400px) {
-  .card--dark, .card--primary {
+  .card--dark,
+  .card--primary {
     min-height: 500px;
   }
 }
@@ -1582,4 +1587,10 @@ body.mobile-nav-open {
 
 .plyr__poster {
   display: none !important;
+}
+
+.github-stars {
+  font-size: 20px;
+  font-family: math;
+  font-weight: 500;
 }


### PR DESCRIPTION
Displaying live GitHub stars count next to the GitHub icon using the GitHub API. 

Changes Made:

Added lib/fetchStars.js to fetch and format star count

Updated HTML with <span class="github-stars"></span> next to GitHub icons

Automatically fetches and renders star count on page load

Why:

Adds social proof and community credibility by showcasing repository popularity.
It's like an Archivement for a Github Repo.

<img width="1919" height="861" alt="Screenshot 2025-07-12 005820" src="https://github.com/user-attachments/assets/b0c0f7e2-fc16-48f9-a3db-b214f769a098" />
